### PR TITLE
Added create_zone_rt flag so it's not dependent on a NAT Gateway being configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 | cloudtrail_bucket | A bucket to push the cloudtrail events to | `` | no |
 | create_kms | Indicates you wish to enable a managed kms key for this cluster | `false` | no |
 | create_zone | Indicates you want this module to create the hosting domain for you | `true` | no |
+| create_zone_rt | Indicates if you wish to create a route table for the AZs (should be true if nat_gateway is true) | `true` | no |
 | dns_zone | The route53 hosting zone for this cluster | `` | no |
 | elb_netmask_offset | The network mask used to calculate the ELB subnets | `8` | no |
 | elb_subnet_offset | The network offset for the ELB subnets | `20` | no |
@@ -15,7 +16,7 @@
 | ingress_sg_name | The name of the security group for the ingress nodes | `ingress-additional` | no |
 | kms_deletion_window | The number of days for the KMS will stay post deletion | `30` | no |
 | kops_state_bucket | The name of the state bucket to use for kops | `` | no |
-| nat_gateway | Indicates if you wish to create a NAT gatewaes or not | `true` | no |
+| nat_gateway | Indicates if you wish to create a NAT gateways or not | `true` | no |
 | nat_netmask_offset | The network mask used to calculate the NAT subnets | `8` | no |
 | nat_subnet_offset | The network offset for the NAT subnets | `30` | no |
 | tags | A set of tags applied to the vpc being created | `<map>` | no |

--- a/routing.tf
+++ b/routing.tf
@@ -16,16 +16,9 @@ resource "aws_route" "default_gateway_route" {
   route_table_id         = "${aws_route_table.default.id}"
 }
 
-## Add the route for internet gateway
-resource "aws_route" "default_igw" {
-  destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.main.id}"
-  route_table_id         = "${aws_route_table.default.id}"
-}
-
 ## Availability Zone Routing Tables
 resource "aws_route_table" "az_rts" {
-  count  = "${var.nat_gateway ? length(var.zones) : 0}"
+  count  = "${var.create_zone_rt ? length(var.zones) : 0}"
   vpc_id = "${aws_vpc.main.id}"
 
   tags {

--- a/variables.tf
+++ b/variables.tf
@@ -23,7 +23,12 @@ variable "tags" {
 }
 
 variable "nat_gateway" {
-  description = "Indicates if you wish to create a NAT gatewaes or not"
+  description = "Indicates if you wish to create a NAT gateways or not"
+  default     = true
+}
+
+variable "create_zone_rt" {
+  description = "Indicates if you wish to create a route table for the AZs (should be true if nat_gateway is true)"
   default     = true
 }
 


### PR DESCRIPTION
**NOTE:** A default route to the IGW was being added twice. I've removed this duplication, however terraform may unexpectedly drop the route on the first run and re-add it on the second run. Please be aware when deploying this change, it may need to be deployed twice!

A safer method of deployment is to run a manual `terraform state rm aws_route.default_igw` PRIOR to deploying with this new code.